### PR TITLE
Enable usage from within script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ target/
 
 # Vim files
 *~
+
+perf.log
+perf.svg

--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,10 @@ Run your script under the profiler::
 
   python -m flamegraph -o perf.log myscript.py --your-script args here
 
+Or, run the profiler from your script::
+
+  flamegraph.start_profile_thread(fd=open("./perf.log", "w"))
+
 Run Brendan Gregg's FlameGraph_ tool against the output::
 
   flamegraph.pl --title "MyScript CPU" perf.log > perf.svg

--- a/example.py
+++ b/example.py
@@ -1,0 +1,27 @@
+"""
+Example usage of flamegraph.
+
+To view a flamegraph run these commands:
+$ python example.py
+$ flamegraph.pl perf.log > perf.svg
+$ inkview perf.svg
+"""
+
+import time
+import sys
+import flamegraph
+
+def foo():
+    time.sleep(.1)
+    bar()
+
+def bar():
+    time.sleep(.05)
+
+if __name__ == "__main__":
+    flamegraph.start_profile_thread(fd=open("./perf.log", "w"))
+
+    N = 10
+    for x in xrange(N):
+        print "{}/{}".format(x, N)
+        foo()

--- a/flamegraph/__init__.py
+++ b/flamegraph/__init__.py
@@ -1,1 +1,1 @@
-# Python package
+from flamegraph import start_profile_thread, ProfileThread


### PR DESCRIPTION
I have an application which cannot be started by flamegraph.
This PR adds the ability to use flamegraph easily within an existing program.
Drop the line `flamegraph.start_profile_thread(fd=open("./perf.log", "w"))` into a script and profiling will start.

`start_profile_thread` is a small convenience method that starts up a `flamegraph.ProfileThread`.

I changed it so that the writing of results happens either when the thread is stopped or at an `atexit` hook. Writing only happens once.