### PR TITLE
Add test suite to help new contributors detect regressions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+[run]
+branch = True
+source = flamegraph
+
+[paths]
+source =
+  src/flamegraph
+  .tox/*/Lib/site-packages/flamegraph
+  .tox/*/lib/python*/site-packages/flamegraph

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+
+
+[flake8]
+ignore =
+  E111  # indentation is not a multiple of four
+  E114  # indentation is not a multiple of four (comment)
+  E121  # continuation line under-indented for hanging indent
+  E128  # continuation line under indented
+  E261  # at least two spaces before inline comment
+  E302  # expected 2 blank lines, found 1
+  E303  # too many blank lines
+  E305  # expected 2 blank lines after class
+  E501  # line too long

--- a/flamegraph/__init__.py
+++ b/flamegraph/__init__.py
@@ -1,1 +1,15 @@
-from .flamegraph import start_profile_thread, ProfileThread
+# -*- coding: utf-8 -*-
+
+
+from .flamegraph import (
+    start_profile_thread,
+    profile,
+    ProfileThread,
+)
+
+
+__all__ = (
+    'start_profile_thread',
+    'profile',
+    'ProfileThread',
+)

--- a/flamegraph/__main__.py
+++ b/flamegraph/__main__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
-from flamegraph import flamegraph
-if __name__ == '__main__':
-  flamegraph.main()
+from flamegraph.flamegraph import main
+if __name__ == '__main__':  # pragma: no cover
+  main()

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,12 @@ setup(
       'License :: Public Domain',
       'Programming Language :: Python',
       'Topic :: Software Development :: Debuggers',
-      ]
-    )
+    ],
+    entry_points={
+        'console_scripts': [
+            'flamegraph = flamegraph.__main__:main',
+        ],
+    },
+)
 
 

--- a/tests/hello.py
+++ b/tests/hello.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function
+
+import time
+
+print('Hello, world!')
+time.sleep(0.1)

--- a/tests/requirements.in
+++ b/tests/requirements.in
@@ -1,0 +1,5 @@
+coverage==4.4.2
+flake8==3.5.0
+mock==2.0.0
+pytest==3.3.2
+

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,18 @@
+--trusted-host pypi.rdv.geo.ubisoft.onbe
+
+attrs==17.4.0             # via pytest
+colorama==0.3.9           # via pytest
+configparser==3.5.0       # via flake8
+coverage==4.4.2
+enum34==1.1.6             # via flake8
+flake8==3.5.0
+funcsigs==1.0.2           # via mock, pytest
+mccabe==0.6.1             # via flake8
+mock==2.0.0
+pbr==3.1.1                # via mock
+pluggy==0.6.0             # via pytest
+py==1.5.2                 # via pytest
+pycodestyle==2.3.1        # via flake8
+pyflakes==1.6.0           # via flake8
+pytest==3.3.2
+six==1.11.0               # via mock, pytest

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+
+import subprocess
+import sys
+
+import flamegraph.__main__
+
+
+def noop(*args):
+    pass
+
+
+noop(flamegraph.__main__)  # for 100% coverage
+
+
+def test_run_as_module():
+    output = subprocess.check_output([
+        sys.executable,
+        '-m', 'flamegraph', '--help'
+    ])
+    output = output.decode('utf-8')
+    assert 'usage' in output
+
+
+def test_run_as_program():
+    output = subprocess.check_output([
+        'flamegraph', '--help'
+    ])
+    output = output.decode('utf-8')
+    assert 'usage' in output

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+
+
+import mock
+import os.path
+import pytest
+import uuid
+
+from flamegraph.flamegraph import main
+
+__here__ = os.path.dirname(os.path.abspath(__file__))
+
+
+def test_main_fail_on_invalid_command(capsys):
+    argv = [
+        'flamegraph',
+    ]
+    with mock.patch('sys.argv', argv):
+        with pytest.raises(SystemExit) as exc:
+            print(main())
+        assert exc.value.args[0] == 2
+    output, errors = capsys.readouterr()
+    assert output == ''
+    assert 'usage' in errors
+
+
+def test_main_fail_on_missing_script_file(capsys):
+    argv = [
+        'flamegraph',
+        str(uuid.uuid4()) + '.py',
+    ]
+    with mock.patch('sys.argv', argv):
+        with pytest.raises(SystemExit) as exc:
+            print(main())
+        assert exc.value.args[0] == 2
+    output, errors = capsys.readouterr()
+    assert 'Script file does not exist' in errors
+    assert 'usage' in errors
+
+
+def test_main(capsys):
+    argv = [
+        'flamegraph',
+        '-i', str(0.01),
+        os.path.join(__here__, 'hello.py'),
+    ]
+    with mock.patch('sys.argv', argv):
+        main()
+
+    output, errors = capsys.readouterr()
+
+    # Standard output contains script output.
+    assert 'Hello, world!' in output
+
+    # Standard output contains stats.
+    assert 'Elapsed Time:' in output
+
+    # Standard error contains frames.
+    lines = errors.split('\n')
+    lines = [line for line in lines if line]
+    assert len(lines) >= 1

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,197 @@
+# -*- coding: utf-8 -*-
+
+
+import contextlib
+import six
+import sys
+import time
+import threading
+import traceback
+
+from flamegraph.flamegraph import (
+    create_flamegraph_entry,
+    default_format_entry,
+    get_thread_name,
+    profile,
+)
+
+
+@contextlib.contextmanager
+def nursery():
+    """Ensure cleanup of test threads."""
+
+    e = threading.Event()
+
+    def run():
+        e.wait()
+
+    threads = set()
+
+    def spawn(name):
+        t = threading.Thread(
+            target=run, name=name,
+        )
+        t.start()
+        threads.add(t)
+        return t
+
+    try:
+        yield spawn
+    finally:
+        e.set()
+        for t in threads:
+            pass
+
+
+def test_get_thread_name():
+    """The thread name is used when the thread exists."""
+
+    with nursery() as spawn:
+        t1 = spawn('test-thread-1')
+        t2 = spawn('test-thread-2')
+
+        assert get_thread_name(t1.ident) == 'test-thread-1'
+        assert get_thread_name(t2.ident) == 'test-thread-2'
+        assert get_thread_name(0xffffffff) == str(0xffffffff)
+
+
+def test_get_thread_name_thread_not_found():
+    """The thread name equals the thread ID when the thread does not exist."""
+
+    assert get_thread_name(0xffffffff) == str(0xffffffff)
+
+
+def test_default_format_entry():
+    """Frame formatting is compatible with the reference implementation."""
+
+    thread_name = 'main'
+
+    def foo():
+        stack = traceback.extract_stack()
+        fn, ln, fun, _ = stack[-1]
+        return default_format_entry(thread_name, fn, ln, fun)
+
+    assert foo() == 'main`foo'
+
+
+def test_create_flamegraph_entry():
+    """Frame formatting is compatible with the reference implementation."""
+
+    thread_name = 'main'
+
+    def bar():
+        frame = sys._current_frames()[threading.current_thread().ident]
+        stack = traceback.extract_stack(frame)[-2:]
+        return create_flamegraph_entry(
+            thread_name, stack, default_format_entry,
+        )
+
+    def foo():
+        return bar()
+
+    assert foo() == 'main`foo;main`bar'
+
+
+def test_create_flamegraph_entry_collapse_recursion():
+    """Frame formatting can collapse recursion."""
+
+    thread_name = 'main'
+
+    def bar(collapse):
+        frame = sys._current_frames()[threading.current_thread().ident]
+        stack = traceback.extract_stack(frame)[-4:]
+        return create_flamegraph_entry(
+            thread_name, stack, default_format_entry, collapse,
+        )
+
+    def foo(collapse, n):
+        if n > 0:
+            return foo(collapse, n - 1)
+        return bar(collapse)
+
+    assert foo(False, 3) == 'main`foo;main`foo;main`foo;main`bar'
+    assert foo(True, 3) == 'main`foo;main`bar'
+
+
+def test_profile():
+    """Profiling can be run in the background."""
+
+    stream = six.StringIO()
+    with nursery() as spawn:
+        spawn('test-thread-1')
+        spawn('test-thread-2')
+
+        profile_args = (
+            stream,
+            0.01,  # 10ms
+            None,
+            default_format_entry,
+            False,
+        )
+        with profile(*profile_args):
+            time.sleep(0.1)
+
+    # Grab non-empty lines output to `stream`.
+    lines = stream.getvalue().split('\n')
+    lines = [line for line in lines if line]
+
+    assert len(lines) >= 1
+    assert all(len(line.split(';')) >= 1 for line in lines)
+
+
+def test_profile_filter_include():
+    """Profiling can selectively grab stack traces."""
+
+    # NOTE: all results will include this string.
+    f = r'test'
+
+    stream = six.StringIO()
+    with nursery() as spawn:
+        spawn('test-thread-1')
+        spawn('test-thread-2')
+
+        profile_args = (
+            stream,
+            0.01,  # 10ms
+            f,
+            default_format_entry,
+            False,
+        )
+        with profile(*profile_args):
+            time.sleep(0.1)
+
+    # Grab non-empty lines output to `stream`.
+    lines = stream.getvalue().split('\n')
+    lines = [line for line in lines if line]
+
+    assert len(lines) >= 1
+    assert all(len(line.split(';')) >= 1 for line in lines)
+    assert all('test' in line for line in lines)
+
+
+def test_profile_filter_exclude():
+    """Profiling can selectively grab stack traces."""
+
+    # NOTE: this will exclude all results.
+    f = r'fubar'
+
+    stream = six.StringIO()
+    with nursery() as spawn:
+        spawn('test-thread-1')
+        spawn('test-thread-2')
+
+        profile_args = (
+            stream,
+            0.01,  # 10ms
+            f,
+            default_format_entry,
+            False,
+        )
+        with profile(*profile_args):
+            time.sleep(0.1)
+
+    # Grab non-empty lines output to `stream`.
+    lines = stream.getvalue().split('\n')
+    lines = [line for line in lines if line]
+
+    assert len(lines) == 0

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+
+[tox]
+envlist =
+  py35
+  py27
+
+
+[testenv]
+deps = -rtests/requirements.txt
+commands =
+  flake8 flamegraph/ tests/
+  coverage run -m pytest -s -vv tests/
+  coverage html
+  coverage report -m --fail-under=100
+
+
+[testenv:deps]
+deps =
+  pip-tools
+commands =
+  pip-compile -v --rebuild --upgrade --no-header --no-index \
+    -o tests/requirements.txt tests/requirements.in


### PR DESCRIPTION
I'm hoping to contribute a number of small usability fixes (e.g. see #14) and I would like to do so without fear of breaking your neat package -- I would not want my contributions to be a burden for you.  In order to facilitate this process, I propose to include some basic continuous integration system that help detect regressions.

Build systems are a sensitive topic and different people tend to have strong opinions about them.  If this is too intrusive, feel free to let me know :-)

This change includes a fairly "plain" test suite based on [tox](https://tox.readthedocs.io/en/latest/) and [pytest](https://docs.pytest.org/en/latest/).  It includes [a linter](http://flake8.pycqa.org/en/latest/) and [code coverage](https://coverage.readthedocs.io/en/coverage-4.4.2/) measurement.

The new tests reach 100% code coverage and enforce future builds to do the same (see `coverage report --fail-under=100` in `tox.ini`).

The builds use pip-tools to pin requirements in order to make builds reproducible over time (upstream updates will not cause the build to break).

I tried to make as few changes to the code as I could in order to make it straightforward to review.  I still made a few changes here and there when it simplified the test suite.

If you accept this contribution, I can help you set up a continuous integration build using [Travis-CI](https://travis-ci.org/) (it's free and takes less than 5 minutes to set up).  From then on, you would get a build report automatically any time someone sends a pull request!