### PR TITLE
Use time.perf_counter when python version >= 3.3

### DIFF
--- a/flamegraph/flamegraph.py
+++ b/flamegraph/flamegraph.py
@@ -143,7 +143,10 @@ def main():
   script_compiled = compile(open(args.script_file, 'rb').read(), args.script_file, 'exec')
   script_globals = {'__name__': '__main__', '__file__': args.script_file, '__package__': None}
 
-  start_time = time.clock()
+  if sys.version_info >= (3,3):
+    start_time = time.perf_counter()
+  else:
+    start_time = time.clock()
   thread.start()
 
   try:
@@ -152,8 +155,13 @@ def main():
   finally:
     thread.stop()
     thread.join()
+    if sys.version_info >= (3,3):
+      elapsed_time = time.perf_counter() - start_time
+    else:
+      elapsed_time = time.clock() - start_time
+    thread.start()
     print('Elapsed Time: %2.2f seconds.  Collected %d stack frames (%d unique)'
-        % (time.clock() - start_time, thread.num_frames(), thread.num_frames(unique=True)))
+        % (elapsed_time, thread.num_frames(), thread.num_frames(unique=True)))
 
 if __name__ == '__main__':
   main()


### PR DESCRIPTION
[time.clock()](https://docs.python.org/3.7/library/time.html#time.clock) was deprecated in python 3.3
"Deprecated since version 3.3: The behaviour of this function depends on the platform: use perf_counter() or process_time() instead, depending on your requirements, to have a well defined behaviour."

[time.perf_counter()](https://docs.python.org/3.7/library/time.html#time.perf_counter) was introduced in python 3.3
"Return the value (in fractional seconds) of a performance counter, i.e. a clock with the highest available resolution to measure a short duration. It does include time elapsed during sleep and is system-wide. The reference point of the returned value is undefined, so that only the difference between the results of consecutive calls is valid.

New in version 3.3."